### PR TITLE
BUG: Use of current_time() in wp_schedule_event didn't always…

### DIFF
--- a/pmpro-payflow-recurring-orders.php
+++ b/pmpro-payflow-recurring-orders.php
@@ -24,7 +24,7 @@ Author URI: http://www.strangerstudios.com
 //activation
 function pmpropfpro_activation()
 {	
-	wp_schedule_event(current_time(), 'hourly', 'pmpro_payflow_recurring_orders');
+	wp_schedule_event(time(), 'hourly', 'pmpro_payflow_recurring_orders');
 }
 register_activation_hook(__FILE__, 'pmpropfpro_activation');
 


### PR DESCRIPTION
...register the `pmpro_payflow_recurring_orders` WP Cron. Updated to use WordPress recommended `time()` instead:

https://codex.wordpress.org/Function_Reference/wp_schedule_event