### PR TITLE
Marking the plugin as MMPU-incompatible

### DIFF
--- a/pmpro-payflow-recurring-orders.php
+++ b/pmpro-payflow-recurring-orders.php
@@ -357,6 +357,15 @@ function pmpropfro_paymentAfter( $payments, $time ) {
 	return false;
 }
 
+/**
+ * Mark the plugin as MMPU-incompatible.
+ */
+function pmpropfro_mmpu_incompatible_add_ons( $incompatible ) {
+	$incompatible[] = 'PMPro Payflow Recurring Orders Add On';
+	return $incompatible;
+}
+add_filter( 'pmpro_mmpu_incompatible_add_ons', 'pmpropfro_mmpu_incompatible_add_ons' );
+
 /*
 	Function to add links to the plugin row meta
 */


### PR DESCRIPTION
Marking the plugin as MMPU-incompatible for PMPro v3.0 update